### PR TITLE
Fix issues when using Java 12.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
+              <source>8</source>
               <additionalparam>-Xdoclint:none</additionalparam>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.2</version>
         <configuration>
           <skipTests>${skipUTs}</skipTests>
         </configuration>


### PR DESCRIPTION
Two issues pop up immediately when trying to do a `mvn clean install`. A NPE with the surefire plugin and an error with Javadoc generation. These two commits resolve those issues.