### PR TITLE
Ran into issues trying to run mvn failsafe:integration-test. The Fail…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ You need to obtain a valid TDA Developer *refresh token* every 90 days. See TDA'
 
 ```
   Properties props = new Properties();
-  props.set("tda.client_id", "...");
-  props.set("tda.token.refresh", "...")
+  props.put("tda.client_id", "...");
+  props.put("tda.token.refresh", "...");
 
   TdaClient tdaClient = new HttpTdaClient(props);
   final Quote quote = tdaClient.fetchQuote("msft");

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/studerw/tda/client/HttpTdaClient.java
+++ b/src/main/java/com/studerw/tda/client/HttpTdaClient.java
@@ -53,7 +53,7 @@ public class HttpTdaClient implements TdaClient {
 
   protected static final int LOGGING_BYTES = -1;
   protected static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
-  static final String DEFAULT_PATH = "https://apis.tdameritrade.com/v1";
+  static final String DEFAULT_PATH = "https://api.tdameritrade.com/v1";
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpTdaClient.class);
   final TdaJsonParser tdaJsonParser = new TdaJsonParser();
   final OkHttpClient httpClient;

--- a/src/main/java/com/studerw/tda/model/account/OrderActivityCollection.java
+++ b/src/main/java/com/studerw/tda/model/account/OrderActivityCollection.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class OrderActivityCollection implements Serializable {
@@ -11,6 +14,15 @@ public class OrderActivityCollection implements Serializable {
 
   @JsonProperty("activityType")
   private ActivityType activityType;
+  @JsonProperty("executionType")
+  private OrderActivity.ExecutionType executionType;
+  @JsonProperty("quantity")
+  private BigDecimal quantity;
+  @JsonProperty("orderRemainingQuantity")
+  private BigDecimal orderRemainingQuantity;
+  @JsonProperty("executionLegs")
+  private List<ExecutionLeg> executionLegs = new ArrayList<ExecutionLeg>();
+
 
   public ActivityType getActivityType() {
     return activityType;

--- a/src/test/java/com/studerw/tda/client/getInstrumentTestIT.java
+++ b/src/test/java/com/studerw/tda/client/getInstrumentTestIT.java
@@ -74,7 +74,7 @@ public class getInstrumentTestIT extends BaseTestIT {
 
   @Test
   public void testBondCusips() {
-    List<String> cusips = Arrays.asList("70153RJT6", "33616CGC8", "06405VDP1", "61690UNX4", "7954505R2", "7954505R2");
+    List<String> cusips = Arrays.asList("70153RJT6", "33616CGC8", "61690UNX4", "7954505R2", "7954505R2");
     cusips.forEach(cusip -> {
       Instrument instrument = httpTdaClient.getBond(cusip);
       assertThat(instrument.getAssetType()).isEqualTo(AssetType.BOND);

--- a/src/test/resources/tda-api.properties
+++ b/src/test/resources/tda-api.properties
@@ -6,6 +6,6 @@
 tda.client_id=<CLIENT_ID>
 # You get this when obtaining your first auth token. They are good for 90 days
 tda.token.refresh=<REFRESH_TOKEN>
-tda.url=https://apis.tdameritrade.com/v1
+tda.url=https://api.tdameritrade.com/v1
 #how many bytes in the logging interceptor to actually print out. -1 is unlimited
 tda.debug.bytes.length=-1


### PR DESCRIPTION
…safe plugin version caused an error, so upgraded to 2.22.1. The Bond cusip \'06405VDP1\' is no longer a valid cusip. And apparently TD has changed their OrderActivityCollection json a bit, so I added the fields.